### PR TITLE
Center Command, Load holograms earlier (#126)

### DIFF
--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsLoadedEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsLoadedEvent.java
@@ -1,0 +1,34 @@
+package de.oliver.fancyholograms.api.events;
+
+import com.google.common.collect.ImmutableList;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public final class HologramsLoadedEvent extends Event {
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    private final ImmutableList<Hologram> holograms;
+
+    public HologramsLoadedEvent(@NotNull final ImmutableList<Hologram> holograms) {
+        super(true);
+
+        this.holograms = holograms;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+    public @NotNull ImmutableList<Hologram> getManager() {
+        return this.holograms;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlerList;
+    }
+
+}

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsUnloadedEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsUnloadedEvent.java
@@ -1,0 +1,34 @@
+package de.oliver.fancyholograms.api.events;
+
+import com.google.common.collect.ImmutableList;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public final class HologramsUnloadedEvent extends Event {
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    private final ImmutableList<Hologram> holograms;
+
+    public HologramsUnloadedEvent(@NotNull final ImmutableList<Hologram> holograms) {
+        super(true);
+
+        this.holograms = holograms;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+    public @NotNull ImmutableList<Hologram> getManager() {
+        return this.holograms;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
@@ -152,7 +152,7 @@ public final class HologramCMD extends Command {
 
             final var usingNpcs = FancyHolograms.isUsingFancyNpcs();
 
-            List<String> suggestions = new ArrayList<>(Arrays.asList("position", "moveHere", "moveTo", "rotate", "rotatepitch", "billboard", "scale", "visibilityDistance", "visibility", "shadowRadius", "shadowStrength", usingNpcs ? "linkWithNpc" : "", usingNpcs ? "unlinkWithNpc" : ""));
+            List<String> suggestions = new ArrayList<>(Arrays.asList("position", "moveHere", "center", "moveTo", "rotate", "rotatepitch", "billboard", "scale", "visibilityDistance", "visibility", "shadowRadius", "shadowStrength", usingNpcs ? "linkWithNpc" : "", usingNpcs ? "unlinkWithNpc" : ""));
             suggestions.addAll(type.getCommands());
 
             return suggestions.stream().filter(input -> input.toLowerCase().startsWith(args[2].toLowerCase(Locale.ROOT))).toList();
@@ -279,6 +279,9 @@ public final class HologramCMD extends Command {
         switch (action) {
             case "position", "movehere" -> {
                 return new MoveHereCMD().run(player, hologram, args);
+            }
+            case "center" -> {
+                return new CenterCMD().run(player, hologram, args);
             }
             case "unlinkwithnpc" -> {
                 return new UnlinkWithNpcCMD().run(player, hologram, args);

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/CenterCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/CenterCMD.java
@@ -1,0 +1,46 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancyholograms.util.Constants;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class CenterCMD implements Subcommand {
+    @Override
+    public List<String> tabcompletion(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        Location location = hologram.getData().getLocation();
+
+        location.set(
+            Math.floor(location.x()) + 0.5,
+            location.y(),
+            Math.floor(location.z()) + 0.5
+        );
+
+        hologram.getData().setLocation(location);
+
+        if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
+            FancyHolograms.get().getHologramStorage().save(hologram);
+        }
+
+        MessageHelper.success(player, "Centered the hologram to %s/%s/%s %s\u00B0 %s\u00B0".formatted(
+            Constants.COORDINATES_DECIMAL_FORMAT.format(location.x()),
+            Constants.COORDINATES_DECIMAL_FORMAT.format(location.y()),
+            Constants.COORDINATES_DECIMAL_FORMAT.format(location.z()),
+            Constants.COORDINATES_DECIMAL_FORMAT.format((location.getYaw() + 180f) % 360f),
+            Constants.COORDINATES_DECIMAL_FORMAT.format((location.getPitch()) % 360f)
+        ));
+        return true;
+    }
+}


### PR DESCRIPTION
* Reduce delay of initial hologram load to first server tick

* Implement `center` subcommand

Allows you to easily center a hologram on a block.

* Add debug for number of loaded holograms

* Fire event when manager loads all holograms

* Add to number of holograms loaded and fix event async

* `HologramsLoadedEvent` now holds the loaded holograms instead of manager.

* revert `Bukkit.isTickingWorlds()` usage

* Update src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java



* Update api/src/main/java/de/oliver/fancyholograms/api/events/HologramsLoadedEvent.java



* apply changes

* Unload event

* Remove `centre` alias for `center` subcommand

---------